### PR TITLE
Refactor Tests And Add First Random Mixin

### DIFF
--- a/randoms/index.js
+++ b/randoms/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+
+const random = new (require('chance'));
+
+// Loads all of the mixins we created and adds them to random/chance, this has to happen first
+random.mixin(require('./mixins'));
+
+// This is where i'll add the mixins to create multiple records, ex: 10 clients, 20 skills, etc.
+// random.mixing({
+//
+// });
+
+
+module.exports = random;

--- a/randoms/mixins/admin.js
+++ b/randoms/mixins/admin.js
@@ -1,0 +1,15 @@
+'use strict';
+
+
+const random = new (require('chance'));
+const Admins = require(`${process.cwd()}/src/models/admins`);
+
+// used to create a random admin. If given no parameters, randomizes all fields.
+module.exports = (opts = {}) => Admins.create({
+	id: opts.id || random.guid(),
+	first_name: opts.first_name || random.name(),
+	last_name: opts.last_name || random.name(),
+	username: opts.username || random.word(),
+	email: opts.email || random.email(),
+	password: opts.password || random.word()
+});

--- a/randoms/mixins/index.js
+++ b/randoms/mixins/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+module.exports = {
+	admin: require('./admin'),
+};

--- a/test/src/helpers.js
+++ b/test/src/helpers.js
@@ -4,7 +4,7 @@
 const connectionOptions = require(`${process.cwd()}/knexfile.js`)[`${process.env.NODE_ENV}`];
 const knex = require('knex')(connectionOptions);
 // TODO: Move the declaraction of random to the random folder and index file when created.
-const random = new (require('chance'));
+const random = require(`${process.cwd()}/randoms`);
 
 
 // TODO: Look into more elegant solution to clear/truncate all tables from db besides a hard coded array.

--- a/test/src/models/admins.js
+++ b/test/src/models/admins.js
@@ -144,12 +144,14 @@ describe('Admins Model', () => {
 	// TODO: write tests for incorrect id and what it returns upon successful delete once that process is refactored. When there is more than one test for the delete describe, create a record for each one
 	describe('has a delete method', () => {
 		it('should delete the record if given a correct id', async() => {
-			const admin = await Admins.findOne(id);
+			const specificId = random.guid();
+			await random.admin({ id: specificId });
+			const admin = await Admins.findOne(specificId);
 			expect(admin).to.be.an.object();
-			expect(admin.id).to.equal(id);
+			expect(admin.id).to.equal(specificId);
 
-			await Admins.delete(id);
-			const afterDelete = await Admins.findOne(id);
+			await Admins.delete(specificId);
+			const afterDelete = await Admins.findOne(specificId);
 
 			expect(afterDelete).to.be.an.object();
 			expect(afterDelete.id).to.equal(undefined);

--- a/test/src/models/admins.js
+++ b/test/src/models/admins.js
@@ -12,8 +12,8 @@ describe('Admins Model', () => {
 	const id = random.guid(),
 		first_name = 'first',
 		last_name = 'last',
-		username= 'username',
-		email= 'email@email.com',
+		username = 'username',
+		email = 'email@email.com',
 		password = 'password';
 	const data = { id, first_name, last_name, username, email, password };
 
@@ -87,18 +87,13 @@ describe('Admins Model', () => {
 		const newFirstName = 'new first',
 			newLastName = 'new last';
 
-		// Used to create an admin with a specific id, email, and username, but same first/last name and password for the below update fields. Expects an object similar to { id, email, username }
-		const createAdmin = (obj) => {
-			const newData = Object.assign({}, data, obj);
-			return random.admin(newData);
-		};
-
 		it('should update the admin record with the given id if given valid data', async() => {
 			const specificId = random.guid(),
 				specificEmail = `${specificId}@email.com`,
 				specificUsername = `username - ${specificId}`,
-				newEmail = `update-${specificEmail}`;
-			await createAdmin({ id: specificId, email: specificEmail, username: specificUsername });
+				newEmail = `update-${specificEmail}`,
+				createData = { id: specificId, email: specificEmail, username: specificUsername };
+			await random.admin(Object.assign({}, data, createData));
 
 			const updateData = { first_name: newFirstName, last_name: newLastName, email: newEmail };
 			const admin = await Admins.findOne(specificId);
@@ -120,8 +115,9 @@ describe('Admins Model', () => {
 		it('should update the admin record with the given id if given valid data, even if only given one field', async() => {
 			const specificId = random.guid(),
 				specificEmail = `${specificId}@email.com`,
-				specificUsername = `username - ${specificId}`;
-			await createAdmin({ id: specificId, email: specificEmail, username: specificUsername });
+				specificUsername = `username - ${specificId}`,
+				createData = { id: specificId, email: specificEmail, username: specificUsername };
+			await random.admin(Object.assign({}, data, createData));
 
 			const updateData = { first_name: newFirstName };
 			const admin = await Admins.findOne(specificId);

--- a/test/src/models/admins.js
+++ b/test/src/models/admins.js
@@ -4,7 +4,7 @@
 const { expect } = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
-const { describe, it, beforeEach } = lab;
+const { describe, it, before } = lab;
 const Admins = require(`${process.cwd()}/src/models/admins`);
 const { db, random, knex } = require(`${process.cwd()}/test/src/helpers`);
 
@@ -12,24 +12,33 @@ describe('Admins Model', () => {
 	const id = random.guid(),
 		first_name = 'first',
 		last_name = 'last',
-		username = 'username',
-		email = 'email@email.com',
+		username= 'username',
+		email= 'email@email.com',
 		password = 'password';
 	const data = { id, first_name, last_name, username, email, password };
 
-	beforeEach(async() => {
-		await db.resetTable('admins');
-		return Admins.create(data);
+
+	before(async() => {
+		await db.resetAll();
+		return random.admin(data);
 	});
 
 
 	describe('has a create method', () => {
+		const newId = random.guid(),
+			username = 'create',
+			email = 'create@email.com';
+
+		const newData = Object.assign({}, data, { id: newId, username, email });
+
+		before(() => Admins.create(newData));
+
 		it('should create a new admin record if given all the necessary info, with a created_at and updated_at field', async () => {
-			const result = await knex('admins').where({ id });
+			const result = await knex('admins').where({ id: newId });
 			const admin = result[0];
 
 			expect(admin).to.be.an.object();
-			expect(admin.id).to.equal(id);
+			expect(admin.id).to.equal(newId);
 			expect(admin.first_name).to.equal(first_name);
 			expect(admin.last_name).to.equal(last_name);
 			expect(admin.email).to.equal(email);
@@ -39,11 +48,11 @@ describe('Admins Model', () => {
 		});
 
 		it('should create a new admin record with a hashed password', async () => {
-			const result = await knex('admins').where({ id });
+			const result = await knex('admins').where({ id: newId });
 			const admin = result[0];
 
 			expect(admin).to.be.an.object();
-			expect(admin.id).to.equal(id);
+			expect(admin.id).to.equal(newId);
 			expect(admin.password).to.be.a.string();
 			expect(admin.password).to.not.equal(password);
 			expect(admin.password.length).to.be.above(password.length);
@@ -76,47 +85,63 @@ describe('Admins Model', () => {
 
 	describe('has an update method', () => {
 		const newFirstName = 'new first',
-			newLastName = 'new last',
-			newEmail = 'new@email.com';
+			newLastName = 'new last';
+
+		// Used to create an admin with a specific id, email, and username, but same first/last name and password for the below update fields. Expects an object similar to { id, email, username }
+		const createAdmin = (obj) => {
+			const newData = Object.assign({}, data, obj);
+			return random.admin(newData);
+		};
 
 		it('should update the admin record with the given id if given valid data', async() => {
+			const specificId = random.guid(),
+				specificEmail = `${specificId}@email.com`,
+				specificUsername = `username - ${specificId}`,
+				newEmail = `update-${specificEmail}`;
+			await createAdmin({ id: specificId, email: specificEmail, username: specificUsername });
+
 			const updateData = { first_name: newFirstName, last_name: newLastName, email: newEmail };
-			const admin = await Admins.findOne(id);
+			const admin = await Admins.findOne(specificId);
 
 			expect(admin).to.be.an.object();
-			expect(admin.id).to.equal(id);
+			expect(admin.id).to.equal(specificId);
 			expect(admin.first_name).to.equal(first_name);
 			expect(admin.last_name).to.equal(last_name);
-			expect(admin.email).to.equal(email);
+			expect(admin.email).to.equal(specificEmail);
 
-			await Admins.update(id, updateData);
+			await Admins.update(specificId, updateData);
 
-			const updatedAdmin = await Admins.findOne(id);
+			const updatedAdmin = await Admins.findOne(specificId);
 			expect(updatedAdmin.first_name).to.equal(newFirstName);
 			expect(updatedAdmin.last_name).to.equal(newLastName);
 			expect(updatedAdmin.email).to.equal(newEmail);
 		});
 
-		it('should update the admin record with the given id if given valid data, even if not given all fields', async() => {
+		it('should update the admin record with the given id if given valid data, even if only given one field', async() => {
+			const specificId = random.guid(),
+				specificEmail = `${specificId}@email.com`,
+				specificUsername = `username - ${specificId}`;
+			await createAdmin({ id: specificId, email: specificEmail, username: specificUsername });
+
 			const updateData = { first_name: newFirstName };
-			const admin = await Admins.findOne(id);
+			const admin = await Admins.findOne(specificId);
 
 			expect(admin).to.be.an.object();
-			expect(admin.id).to.equal(id);
+			expect(admin.id).to.equal(specificId);
 			expect(admin.first_name).to.equal(first_name);
 			expect(admin.last_name).to.equal(last_name);
-			expect(admin.email).to.equal(email);
+			expect(admin.email).to.equal(specificEmail);
 
-			await Admins.update(id, updateData);
+			await Admins.update(specificId, updateData);
 
-			const updatedAdmin = await Admins.findOne(id);
+			const updatedAdmin = await Admins.findOne(specificId);
 			expect(updatedAdmin.first_name).to.equal(newFirstName);
 			expect(updatedAdmin.last_name).to.equal(last_name);
-			expect(updatedAdmin.email).to.equal(email);
+			expect(updatedAdmin.email).to.equal(specificEmail);
 		});
 	});
 
-	// TODO: write tests for incorrect id and what it returns upon successful delete once that process is refactored
+	// TODO: write tests for incorrect id and what it returns upon successful delete once that process is refactored. When there is more than one test for the delete describe, create a record for each one
 	describe('has a delete method', () => {
 		it('should delete the record if given a correct id', async() => {
 			const admin = await Admins.findOne(id);

--- a/test/src/models/admins.js
+++ b/test/src/models/admins.js
@@ -141,11 +141,12 @@ describe('Admins Model', () => {
 		});
 	});
 
-	// TODO: write tests for incorrect id and what it returns upon successful delete once that process is refactored. When there is more than one test for the delete describe, create a record for each one
+	// TODO: write tests for incorrect id and what it returns upon successful delete once that process is refactored
 	describe('has a delete method', () => {
 		it('should delete the record if given a correct id', async() => {
 			const specificId = random.guid();
 			await random.admin({ id: specificId });
+
 			const admin = await Admins.findOne(specificId);
 			expect(admin).to.be.an.object();
 			expect(admin.id).to.equal(specificId);


### PR DESCRIPTION
## Overview
refactor the tests in the admin model to speed things up, remove unnecessary trips to the db, etc. And to implement a more advanced use of npm chance, by adding the random mixin directory.
- [x] create random/mixin directory
- [x] add admin mixin setup mixing structure
- [x] refactor admin tests


## Checklist
- Does this PR have unit tests to cover the changes? yes
- Does this PR create migration(s)? no
