### PR TITLE
Speed Up Clients Mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Created 02/27/2018
 A freelancing website based off of the concepts of sites such as upwork. This is a practice project, it is not intended to become an in production website. The technologies used are Node.js with Express.js for the backend, Postgres for the database, and ReactJS for the starting front end. The starting focus of this project is on code quality, enforcing code standards with ESLint, connecting Node.js with React.js, unit testing, stronger github practices, and continous integration via Circleci.
 
 ## Getting Started
-You need Node.js, nodemon, and postgres installed to use this project locally.
+You need Node.js, nodemon, npm, and postgres installed to use this project locally.
 
 To get started, you need to create a '.env' file in the main project directory. Model it after the .env.example file, simply create necessary variables for your database and starting admin.
 
@@ -23,6 +23,20 @@ You can run the project with the following command.
 ```
 npm run server
 ```
+
+## Overall Directory
+The project is directory is broken down into a few key sub directories listed below.
+* **.circleci** - Used by CircleCi
+* **.github** - Used by github, contains PR template
+* **bin** - Contains executable scripts, such as the scripts to create the database and initial admin
+* **migrations** - The migrations files used by knex to structure the databases
+* **public** -This is the client facing directory, contains front end code, templates, static files, etc.
+* **randoms** - Contains my custom mixins for the Chance module
+* **seeds** - Used by knex to populate the database via scripts
+* **src** - This is the back end code, knex options, models, helper files, etc.
+* **test** - This is the test directory, meant to mirror the main directory and the applicable folders, so it has a sub src and public directory
+
+
 ## Testing
 This project uses npm Lab and Code to run its tests. Other npm modules used include Chance. It uses a separate test database, that mirrors the main database, using the same migrations without the seed data.
 
@@ -34,4 +48,4 @@ npm run test
 ## General Info
 TBD
 
-Last updated: 5/16/18
+Last updated: 5/22/18

--- a/randoms/index.js
+++ b/randoms/index.js
@@ -16,7 +16,7 @@ random.mixin({
 			opts.field_id = random.guid();
 			await random.field({ id: opts.field_id });
 		}
-		// When creating several clients (ex: 50), we want to skip hashing the password 50 times in the client mixin or model, which is by far the most time consuming part of it. So we hash one password and give all 50 clients that same password, speeds up the 50 inserts by roughtly 9 times. Or, we can pass in 'dontHash' = false, to make it hash the given plain password or hash a random word in the mixin like normal. We tell the client mixin not to hash via the 'dontHash' variable below
+		// When creating several clients (ex: 50), we want to skip hashing the password 50 times in the client mixin or model, which is by far the most time consuming part of it. So we hash one password and give all 50 clients that same password, speeds up the 50 inserts by roughly 9 times. Or, we can pass in 'dontHash' = false, to make it hash the given plain password or hash a random word in the mixin like normal. We tell the client mixin not to hash via the 'dontHash' variable below
 		if (dontHash) {
 			opts.password = hashPassword('password');
 			opts.dontHash = true;

--- a/randoms/index.js
+++ b/randoms/index.js
@@ -10,6 +10,7 @@ random.mixin(require('./mixins'));
 
 // methods that create multiple records, ex: 10 clients, 20 skills, etc.
 random.mixin({
+
 	clients: async(count = 10, opts = {}, dontHash = true) => {
 		if (!opts.field_id) {
 			opts.field_id = random.guid();
@@ -30,7 +31,23 @@ random.mixin({
 		const fields = _.times(count, () => random.field(opts));
 		return Promise.all(fields);
 	},
-	
+
+
+	freelancers: async(count = 10, opts = {}, dontHash = true) => {
+		if (!opts.field_id) {
+			opts.field_id = random.guid();
+			await random.field({ id: opts.field_id });
+		}
+		// see above explanation in the clients mixin as to why this step is here.
+		if (dontHash) {
+			opts.password = hashPassword('password');
+			opts.dontHash = true;
+		}
+
+		const freelancers = _.times(count, () => random.freelancer(opts));
+		return Promise.all(freelancers);
+	},
+
 
 	skills: (count = 10, opts = {}) => {
 		const skills = _.times(count, () => random.skill(opts));

--- a/randoms/index.js
+++ b/randoms/index.js
@@ -2,6 +2,7 @@
 
 
 const random = new (require('chance'));
+const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
 // Loads all of the mixins we created and adds them to random/chance, this has to happen first
@@ -9,19 +10,27 @@ random.mixin(require('./mixins'));
 
 // methods that create multiple records, ex: 10 clients, 20 skills, etc.
 random.mixin({
-	clients: async(count = 10, opts = {}) => {
+	clients: async(count = 10, opts = {}, dontHash = true) => {
 		if (!opts.field_id) {
 			opts.field_id = random.guid();
 			await random.field({ id: opts.field_id });
 		}
+		// When creating several clients (ex: 50), we want to skip hashing the password 50 times in the client mixin or model, which is by far the most time consuming part of it. So we hash one password and give all 50 clients that same password, speeds up the 50 inserts by roughtly 9 times. Or, we can pass in 'dontHash' = false, to make it hash the given plain password or hash a random word in the mixin like normal. We tell the client mixin not to hash via the 'dontHash' variable below
+		if (dontHash) {
+			opts.password = hashPassword('password');
+			opts.dontHash = true;
+		}
+
 		const clients = _.times(count, () => random.client(opts));
 		return Promise.all(clients);
 	},
+
 
 	fields: (count = 10, opts = {}) => {
 		const fields = _.times(count, () => random.field(opts));
 		return Promise.all(fields);
 	},
+	
 
 	skills: (count = 10, opts = {}) => {
 		const skills = _.times(count, () => random.skill(opts));

--- a/randoms/mixins/client.js
+++ b/randoms/mixins/client.js
@@ -14,7 +14,8 @@ module.exports = (opts = {}) => {
 	if (opts.dontHash) {
 		password = opts.password;
 	} else {
-		password = hashPassword(opts.password) || hashPassword(random.word());
+		const beforeHash = opts.password || random.word();
+		password = hashPassword(beforeHash);
 	}
 
 	return Clients.createWithoutHash({

--- a/randoms/mixins/client.js
+++ b/randoms/mixins/client.js
@@ -3,23 +3,35 @@
 
 const random = new (require('chance'));
 const Clients = require(`${process.cwd()}/src/models/clients`);
+const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 
 // used to create a random skill. If given no parameters, randomizes all fields.
 // A field_id is required, for simplicity we don't create a new field here
-module.exports = (opts = {}) => Clients.create({
-	id: opts.id || random.guid(),
-	first_name: opts.first_name || random.name(),
-	last_name: opts.last_name || random.name(),
-	username: opts.username || `${random.guid().substring(0, 16)}-clientUserName`,
-	email: opts.email || `${random.guid().substring(0, 16)}@client.com`,
-	gender: opts.gender || 'male',
-	age: opts.age || 20,
-	field_id: opts.field_id,
-	summary: opts.summary || random.paragraph(),
-	state: opts.state || 'TX',
-	city: opts.city || random.word(),
-	zip: opts.zip || random.zip(),
-	phone: opts.phone || random.phone(),
-	dob: opts.dob || random.date({ string: true }),
-	password: opts.password || random.word()
-});
+module.exports = (opts = {}) => {
+	let password;
+
+	// When going through the clients mixin to create multiple client records (ex: 50), we don't hash every password, far too time consuming, so the 'dontHash' will be true, telling this mixin not to hash it, we hash the password in the clients mixin, and it is passed in the opts object. If 'dontHash' is false, then we hash either the given plain password or a random word like normal.
+	if (opts.dontHash) {
+		password = opts.password;
+	} else {
+		password = hashPassword(opts.password) || hashPassword(random.word());
+	}
+
+	return Clients.createWithoutHash({
+		id: opts.id || random.guid(),
+		first_name: opts.first_name || random.name(),
+		last_name: opts.last_name || random.name(),
+		username: opts.username || `${random.guid().substring(0, 16)}-clientUserName`,
+		email: opts.email || `${random.guid().substring(0, 16)}@client.com`,
+		gender: opts.gender || 'male',
+		age: opts.age || 20,
+		field_id: opts.field_id,
+		summary: opts.summary || random.paragraph(),
+		state: opts.state || 'TX',
+		city: opts.city || random.word(),
+		zip: opts.zip || random.zip(),
+		phone: opts.phone || random.phone(),
+		dob: opts.dob || random.date({ string: true }),
+		password,
+	});
+};

--- a/randoms/mixins/client.js
+++ b/randoms/mixins/client.js
@@ -5,7 +5,7 @@ const random = new (require('chance'));
 const Clients = require(`${process.cwd()}/src/models/clients`);
 const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 
-// used to create a random skill. If given no parameters, randomizes all fields.
+// used to create a random client. If given no parameters, randomizes all fields.
 // A field_id is required, for simplicity we don't create a new field here
 module.exports = (opts = {}) => {
 	let password;

--- a/randoms/mixins/client.js
+++ b/randoms/mixins/client.js
@@ -10,7 +10,7 @@ const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 module.exports = (opts = {}) => {
 	let password;
 
-	// When going through the clients mixin to create multiple client records (ex: 50), we don't hash every password, far too time consuming, so the 'dontHash' will be true, telling this mixin not to hash it, we hash the password in the clients mixin, and it is passed in the opts object. If 'dontHash' is false, then we hash either the given plain password or a random word like normal.
+	// When going through the clients mixin to create multiple client records (ex: 50), we don't hash every password, far too time consuming. So if the 'dontHash' variable in opts is true, it's telling this mixin to not hash it. We instead hash it in the clients mixin and pass it to this mixin. if 'dontHash' is false, then we hash either the given plain password or a random word like normal below
 	if (opts.dontHash) {
 		password = opts.password;
 	} else {

--- a/randoms/mixins/freelancer.js
+++ b/randoms/mixins/freelancer.js
@@ -10,7 +10,7 @@ const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 module.exports = (opts = {}) => {
 	let password;
 
-	// When going through the freelancers mixin to create multiple freelancer records (ex: 50), we don't hash every password, far too time consuming, so the 'dontHash' will be true, telling this mixin not to hash it, we hash the password in the freelancers mixin, and it is passed in the opts object. If 'dontHash' is false, then we hash either the given plain password or a random word like normal.
+	// When going through the freelancers mixin to create multiple freelancer records (ex: 50), we don't hash every password, far too time consuming. So if the 'dontHash' variable in opts is true, it's telling this mixin to not hash it. We instead hash it in the freelancers mixin and pass it to this mixin. if 'dontHash' is false, then we hash either the given plain password or a random word like normal below
 	if (opts.dontHash) {
 		password = opts.password;
 	} else {

--- a/randoms/mixins/freelancer.js
+++ b/randoms/mixins/freelancer.js
@@ -1,0 +1,44 @@
+'use strict';
+
+
+const random = new (require('chance'));
+const Freelancers = require(`${process.cwd()}/src/models/freelancers`);
+const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
+
+// used to create a random freelancer. If given no parameters, randomizes all fields.
+// A field_id is required, for simplicity we don't create a new field here
+module.exports = (opts = {}) => {
+	let password;
+
+	// When going through the freelancers mixin to create multiple freelancer records (ex: 50), we don't hash every password, far too time consuming, so the 'dontHash' will be true, telling this mixin not to hash it, we hash the password in the freelancers mixin, and it is passed in the opts object. If 'dontHash' is false, then we hash either the given plain password or a random word like normal.
+	if (opts.dontHash) {
+		password = opts.password;
+	} else {
+		const beforeHash = opts.password || random.word();
+		password = hashPassword(beforeHash);
+	}
+
+	return Freelancers.createWithoutHash({
+		id: opts.id || random.guid(),
+		first_name: opts.first_name || random.name(),
+		last_name: opts.last_name || random.name(),
+		username: opts.username || `${random.guid().substring(0, 16)}-freelancerUserName`,
+		email: opts.email || `${random.guid().substring(0, 16)}@freelancer.com`,
+		job_title: opts.job_title || random.word(),
+		rate: opts.rate || 20,
+		experience_level: opts.experience_level || 'intermediate',
+		video_url: opts.video_url || null,
+		portfolio_url: opts.portfolio_url || null,
+		available: opts.available || 'true',
+		gender: opts.gender || 'male',
+		age: opts.age || 20,
+		field_id: opts.field_id,
+		summary: opts.summary || random.paragraph(),
+		state: opts.state || 'TX',
+		city: opts.city || random.word(),
+		zip: opts.zip || random.zip(),
+		phone: opts.phone || random.phone(),
+		dob: opts.dob || random.date({ string: true }),
+		password,
+	});
+};

--- a/randoms/mixins/index.js
+++ b/randoms/mixins/index.js
@@ -5,5 +5,6 @@ module.exports = {
 	admin: require('./admin'),
 	client: require('./client'),
 	field: require('./field'),
+	freelancer: require('./freelancer'),
 	skill: require('./skill'),
 };

--- a/src/models/admins.js
+++ b/src/models/admins.js
@@ -17,7 +17,7 @@ module.exports = {
 	},
 
 
-	// goes through the mainModel findOne, as opposed to the UserModel findOneUser since admins don't have a field
+	// goes through the mainModel findOne, as opposed to the UserModel findOneUser, since admins don't have a field_id
 	findOne (id) {
 		return Admins.findOne(id)
 			.then((result) => _.omit(result, 'password', 'username'));

--- a/src/models/admins.js
+++ b/src/models/admins.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const Admins = new Model('admins');
 const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');

--- a/src/models/admins.js
+++ b/src/models/admins.js
@@ -12,15 +12,15 @@ module.exports = {
 	},
 
 
+	create (data) {
+		return Admins.createUser(data);
+	},
+
+
 	// goes through the mainModel findOne, as opposed to the UserModel findOneUser since admins don't have a field
 	findOne (id) {
 		return Admins.findOne(id)
 			.then((result) => _.omit(result, 'password', 'username'));
-	},
-
-
-	create (data) {
-		return Admins.createUser(data);
 	},
 
 

--- a/src/models/admins.js
+++ b/src/models/admins.js
@@ -1,35 +1,33 @@
 'use strict';
 
 
-const Model = require('./main_model');
-const Admins = new Model('admins');
-const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
+const UserModel = require('./user_model');
+const Admins = new UserModel('admins');
 const _ = require('lodash');
 
 
 module.exports = {
-
 	getAll () {
 		// TODO: to be setup with pagination later
 	},
 
+
+	// goes through the mainModel findOne, as opposed to the UserModel findOneUser since admins don't have a field
 	findOne (id) {
 		return Admins.findOne(id)
 			.then((result) => _.omit(result, 'password', 'username'));
 	},
 
+
 	create (data) {
-		// hash the password
-		data.password = hashPassword(data.password);
-		return Admins.create(data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Admins.createUser(data);
 	},
 
-	// TODO: Separate update method for updating password and username, perhaps one for email as well. Change model tests accordingly for this method.
+
 	update (id, data) {
-		return Admins.updateById(id, data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Admins.update(id, data);
 	},
+
 
 	delete (id) {
 		return Admins.delete(id);

--- a/src/models/client_reviews.js
+++ b/src/models/client_reviews.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const ClientReviews = new Model('client_reviews');
 
 

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -3,7 +3,6 @@
 
 const Model = require('./model');
 const Clients = new Model('clients');
-const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
 
@@ -19,15 +18,12 @@ module.exports = {
 	},
 
 	create (data) {
-		// hash the password
-		data.password = hashPassword(data.password);
-		return Clients.create(data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Clients.createUser(data);
 	},
 
 	// Same as the create above but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple clients (ex: 50 clients), not to be used in actual data or workflow.
 	createWithoutHash (data) {
-		// Hashed password is already given to save time.
+		// calls the create method above
 		return Clients.create(data)
 			.then((result) => _.omit(result, 'password', 'username'));
 	},

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -1,38 +1,39 @@
 'use strict';
 
 
-const Model = require('./main_model');
+// const Model = require('./main_model');
+const Model = require('./user_model');
 const Clients = new Model('clients');
 const _ = require('lodash');
 
 
 module.exports = {
-
 	getAll () {
 		// TODO: to be setup with pagination later
 	},
 
+
 	findOne (id) {
-		return Clients.findOneUser(id)
-			.then((result) => _.omit(result, 'password', 'field_id', 'username'));
+		return Clients.findOneUser(id);
 	},
+
 
 	create (data) {
 		return Clients.createUser(data);
 	},
 
-	// Same as the create above but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple clients (ex: 50 clients), not to be used in actual data or workflow.
+
 	createWithoutHash (data) {
-		// calls the create method in the main Model
-		return Clients.create(data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Clients.createWithoutHash(data);
 	},
+
 
 	// TODO: Separate update method for updating password and username, perhaps one for emaila and field as well. Change model tests accordingly for this method.
 	update (id, data) {
 		return Clients.updateById(id, data)
 			.then((result) => _.omit(result, 'password', 'username'));
 	},
+
 
 	delete (id) {
 		return Clients.delete(id);

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -11,11 +11,6 @@ module.exports = {
 	},
 
 
-	findOne (id) {
-		return Clients.findOneUser(id);
-	},
-
-
 	create (data) {
 		return Clients.createUser(data);
 	},
@@ -23,6 +18,11 @@ module.exports = {
 
 	createWithoutHash (data) {
 		return Clients.createWithoutHash(data);
+	},
+
+
+	findOne (id) {
+		return Clients.findOneUser(id);
 	},
 
 

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -23,7 +23,7 @@ module.exports = {
 
 	// Same as the create above but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple clients (ex: 50 clients), not to be used in actual data or workflow.
 	createWithoutHash (data) {
-		// calls the create method above
+		// calls the create method in the main Model
 		return Clients.create(data)
 			.then((result) => _.omit(result, 'password', 'username'));
 	},

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const Clients = new Model('clients');
 const _ = require('lodash');
 

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -1,10 +1,8 @@
 'use strict';
 
 
-// const Model = require('./main_model');
-const Model = require('./user_model');
-const Clients = new Model('clients');
-const _ = require('lodash');
+const UserModel = require('./user_model');
+const Clients = new UserModel('clients');
 
 
 module.exports = {
@@ -28,10 +26,8 @@ module.exports = {
 	},
 
 
-	// TODO: Separate update method for updating password and username, perhaps one for emaila and field as well. Change model tests accordingly for this method.
 	update (id, data) {
-		return Clients.updateById(id, data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Clients.update(id, data);
 	},
 
 

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -25,6 +25,13 @@ module.exports = {
 			.then((result) => _.omit(result, 'password', 'username'));
 	},
 
+	// Same as the create above but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple clients (ex: 50 clients), not to be used in actual data or workflow.
+	createWithoutHash (data) {
+		// Hashed password is already given to save time.
+		return Clients.create(data)
+			.then((result) => _.omit(result, 'password', 'username'));
+	},
+
 	// TODO: Separate update method for updating password and username, perhaps one for emaila and field as well. Change model tests accordingly for this method.
 	update (id, data) {
 		return Clients.updateById(id, data)

--- a/src/models/education_history.js
+++ b/src/models/education_history.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const EducationHistory = new Model('education_history');
 
 

--- a/src/models/employment_history.js
+++ b/src/models/employment_history.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const EmploymentHistory = new Model('employment_history');
 
 
@@ -14,7 +14,7 @@ module.exports = {
 	findOne (id) {
 		return EmploymentHistory.findOne(id);
 	},
-	
+
 	// TODO: Limit on number of records per freelancer?
 	create (data) {
 		return EmploymentHistory.create(data);

--- a/src/models/fields.js
+++ b/src/models/fields.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const Fields = new Model('fields');
 
 

--- a/src/models/freelancer_reviews.js
+++ b/src/models/freelancer_reviews.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const FreelancerReviews = new Model('freelancer_reviews');
 
 

--- a/src/models/freelancer_skills.js
+++ b/src/models/freelancer_skills.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const Skills = require('./skills');
 const FreelancerSkills = new Model('freelancer_skills');
 

--- a/src/models/freelancers.js
+++ b/src/models/freelancers.js
@@ -3,7 +3,6 @@
 
 const UserModel = require('./user_model');
 const Freelancers = new UserModel('freelancers');
-const _ = require('lodash');
 
 
 module.exports = {

--- a/src/models/freelancers.js
+++ b/src/models/freelancers.js
@@ -19,8 +19,11 @@ module.exports = {
 	},
 
 	create (data) {
-		// hash the password
-		data.password = hashPassword(data.password);
+		return Freelancers.createUser(data);
+	},
+
+	createWithoutHash (data) {
+		// calls the create method in the main Model
 		return Freelancers.create(data)
 			.then((result) => _.omit(result, 'password', 'username'));
 	},

--- a/src/models/freelancers.js
+++ b/src/models/freelancers.js
@@ -1,9 +1,8 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const Freelancers = new Model('freelancers');
-const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
 

--- a/src/models/freelancers.js
+++ b/src/models/freelancers.js
@@ -1,36 +1,36 @@
 'use strict';
 
 
-const Model = require('./main_model');
-const Freelancers = new Model('freelancers');
+const UserModel = require('./user_model');
+const Freelancers = new UserModel('freelancers');
 const _ = require('lodash');
 
 
 module.exports = {
-
 	getAll () {
 		// TODO: to be setup with pagination later
 	},
 
-	findOne (id) {
-		return Freelancers.findOneUser(id)
-			.then((result) => _.omit(result, 'password', 'field_id', 'username'));
-	},
 
 	create (data) {
 		return Freelancers.createUser(data);
 	},
 
+
 	createWithoutHash (data) {
-		// calls the create method in the main Model
-		return Freelancers.create(data)
-			.then((result) => _.omit(result, 'password', 'username'));
+		return Freelancers.createWithoutHash(data);
 	},
 
-	update (id, data) {
-		return Freelancers.updateById(id, data)
-			.then((result) => _.omit(result, 'password', 'username'));
+
+	findOne (id) {
+		return Freelancers.findOneUser(id);
 	},
+
+
+	update (id, data) {
+		return Freelancers.update(id, data);
+	},
+
 
 	delete (id) {
 		return Freelancers.delete(id);

--- a/src/models/inappropriate_flags.js
+++ b/src/models/inappropriate_flags.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-const Model = require('./model');
+const Model = require('./main_model');
 const InappropriateFlags = new Model('inappropriate_flags');
 
 

--- a/src/models/invitations.js
+++ b/src/models/invitations.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const Invitations = new Model('invitations');
 
 

--- a/src/models/job_activity.js
+++ b/src/models/job_activity.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const JobActivity = new Model('job_activity');
 
 // TODO: determine when a job is added to a freelancer's job activity. Once accepted? Once finished?

--- a/src/models/jobs.js
+++ b/src/models/jobs.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const Jobs = new Model('jobs');
 
 

--- a/src/models/main_model.js
+++ b/src/models/main_model.js
@@ -5,7 +5,9 @@ const knex = require('../config/knex');
 const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
-class Model {
+
+// This is the main Model that is inherited by all other models
+class MainModel {
 	constructor (tableName) {
 		this.tableName = tableName;
 	}
@@ -56,7 +58,7 @@ class Model {
 			});
 	}
 
-	
+
 	create (data) {
 		data.created_at = data.created_at || new Date();
 		return knex(this.tableName).insert(data).returning('*')
@@ -92,4 +94,4 @@ class Model {
 
 }
 
-module.exports = Model;
+module.exports = MainModel;

--- a/src/models/main_model.js
+++ b/src/models/main_model.js
@@ -17,7 +17,17 @@ class MainModel {
 			.then((result) => result[0]);
 	}
 
-	
+
+	findOne (id) {
+		return knex(this.tableName).where({ id })
+			.then((array) => {
+				// In the event of no record found, we still return an empty object for consistency
+				const result = array[0] ? array[0] : {};
+				return result;
+			});
+	}
+
+
 	// find the employment or education history for one freelancer
 	findHistory (id) {
 		return knex(this.tableName).where({ freelancer_id: id });
@@ -39,17 +49,6 @@ class MainModel {
 			.innerJoin('freelancers as f', `${this.tableName}.freelancer_id`, 'f.id')
 			.innerJoin('jobs as j', `${this.tableName}.job_id`, 'j.id')
 			.then((result) => result[0]);
-	}
-
-
-	// find one for any table other than client or freelancer
-	findOne (id) {
-		return knex(this.tableName).where({ id })
-			.then((array) => {
-				// In the event of no record found, we still return an empty object for consistency
-				const result = array[0] ? array[0] : {};
-				return result;
-			});
 	}
 
 

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -2,6 +2,8 @@
 
 
 const knex = require('../config/knex');
+const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
+const _ = require('lodash');
 
 class Model {
 	constructor (tableName) {
@@ -54,11 +56,20 @@ class Model {
 			});
 	}
 
-
+	
 	create (data) {
 		data.created_at = data.created_at || new Date();
 		return knex(this.tableName).insert(data).returning('*')
 			.then((result) => result[0]);
+	}
+
+
+	// Used for users (clients, freelancers, and admins), first hashes the password, then calls the above create method, and finally omitting the password and username, which we don't want passed to the front.
+	createUser (data) {
+		// hash the password
+		data.password = hashPassword(data.password);
+		return this.create(data)
+			.then((result) => _.omit(result, 'password', 'username'));
 	}
 
 

--- a/src/models/proposals.js
+++ b/src/models/proposals.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const Proposals = new Model('proposals');
 
 

--- a/src/models/saved_clients.js
+++ b/src/models/saved_clients.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const SavedClients = new Model('saved_clients');
 
 

--- a/src/models/saved_freelancers.js
+++ b/src/models/saved_freelancers.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const SavedFreelancers = new Model('saved_freelancers');
 
 

--- a/src/models/saved_jobs.js
+++ b/src/models/saved_jobs.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const SavedJobs = new Model('saved_jobs');
 
 

--- a/src/models/skills.js
+++ b/src/models/skills.js
@@ -2,7 +2,7 @@
 
 
 const knex = require('../config/knex');
-const Model = require('./model');
+const Model = require('./main_model');
 const Skills = new Model('skills');
 
 

--- a/src/models/user_model.js
+++ b/src/models/user_model.js
@@ -41,7 +41,7 @@ class UserModel extends MainModel {
 	}
 
 
-	// TODO: Separate update method for updating password and username, perhaps one for emaila and field as well. Change model tests accordingly for this method.
+	// TODO: Separate update method for updating password and username, perhaps one for email and field as well. Change model tests accordingly for this method.
 	update (id, data) {
 		return this.updateById(id, data)
 			.then((result) => _.omit(result, 'password', 'username'));

--- a/src/models/user_model.js
+++ b/src/models/user_model.js
@@ -14,6 +14,7 @@ class UserModel extends MainModel {
 		this.tableName = tableName;
 	}
 
+
 	createUser (data) {
 		// hash the password
 		data.password = hashPassword(data.password);
@@ -21,12 +22,14 @@ class UserModel extends MainModel {
 			.then((result) => _.omit(result, 'password', 'username'));
 	}
 
+
 	// Same as the above create method but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple users (ex: 50 clients), not to be used in actual data or workflow.
 	createWithoutHash (data) {
 		return this.create(data).then((result) => _.omit(result, 'password', 'username'));
 	}
 
-	// select a single client or freelancer, also grabs their field (front end, web development, etc.)
+
+	// also grabs the user's field
 	findOneUser (id) {
 		const selectedColumns = [`${this.tableName}.*`, 'fields.field'];
 		return knex(this.tableName)
@@ -35,6 +38,13 @@ class UserModel extends MainModel {
 			.innerJoin('fields', `${this.tableName}.field_id`, 'fields.id')
 			.then((result) => result[0])
 			.then((result) => _.omit(result, 'password', 'field_id', 'username'));
+	}
+
+
+	// TODO: Separate update method for updating password and username, perhaps one for emaila and field as well. Change model tests accordingly for this method.
+	update (id, data) {
+		return this.updateById(id, data)
+			.then((result) => _.omit(result, 'password', 'username'));
 	}
 
 }

--- a/src/models/user_model.js
+++ b/src/models/user_model.js
@@ -7,7 +7,7 @@ const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
 
-// A specific class that extends the MainModel, used only for users (clients, freelancers, and amdins), to abstract re-used code and improve DRYness
+// A specific class that extends the MainModel, used only for users (clients, freelancers, and admins), to abstract re-used code and improve DRYness
 class UserModel extends MainModel {
 	constructor (tableName) {
 		super(tableName);
@@ -25,11 +25,12 @@ class UserModel extends MainModel {
 
 	// Same as the above create method but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple users (ex: 50 clients), not to be used in actual data or workflow.
 	createWithoutHash (data) {
-		return this.create(data).then((result) => _.omit(result, 'password', 'username'));
+		return this.create(data)
+			.then((result) => _.omit(result, 'password', 'username'));
 	}
 
 
-	// also grabs the user's field
+	// finds one user and grabs the user's field through its field_id
 	findOneUser (id) {
 		const selectedColumns = [`${this.tableName}.*`, 'fields.field'];
 		return knex(this.tableName)

--- a/src/models/user_model.js
+++ b/src/models/user_model.js
@@ -1,0 +1,43 @@
+'use strict';
+
+
+const MainModel = require('./main_model');
+const knex = require('../config/knex');
+const { hashPassword } = require(`${process.cwd()}/src/lib/helper_functions`);
+const _ = require('lodash');
+
+
+// A specific class that extends the MainModel, used only for users (clients, freelancers, and amdins), to abstract re-used code and improve DRYness
+class UserModel extends MainModel {
+	constructor (tableName) {
+		super(tableName);
+		this.tableName = tableName;
+	}
+
+	createUser (data) {
+		// hash the password
+		data.password = hashPassword(data.password);
+		return this.create(data)
+			.then((result) => _.omit(result, 'password', 'username'));
+	}
+
+	// Same as the above create method but it doesn't hash the password. This is only used in tests and random mixins to speed up creation of multiple users (ex: 50 clients), not to be used in actual data or workflow.
+	createWithoutHash (data) {
+		return this.create(data).then((result) => _.omit(result, 'password', 'username'));
+	}
+
+	// select a single client or freelancer, also grabs their field (front end, web development, etc.)
+	findOneUser (id) {
+		const selectedColumns = [`${this.tableName}.*`, 'fields.field'];
+		return knex(this.tableName)
+			.select(selectedColumns)
+			.where(knex.raw(`${this.tableName}.id = '${id}'`))
+			.innerJoin('fields', `${this.tableName}.field_id`, 'fields.id')
+			.then((result) => result[0])
+			.then((result) => _.omit(result, 'password', 'field_id', 'username'));
+	}
+
+}
+
+
+module.exports = UserModel;

--- a/test/src/models/clients.js
+++ b/test/src/models/clients.js
@@ -10,7 +10,7 @@ const { db, random, knex } = require(`${process.cwd()}/test/src/helpers`);
 const _ = require('lodash');
 
 
-describe.only('Clients Model', () => {
+describe('Clients Model', () => {
 	const id = random.guid(),
 		first_name = random.name(),
 		last_name = random.name(),
@@ -33,7 +33,6 @@ describe.only('Clients Model', () => {
 		await db.resetTable('clients');
 		await db.resetTable('fields');
 		await random.field({ id: field_id, field });
-		await random.clients(20);
 		return random.client(data);
 	});
 

--- a/test/src/models/clients.js
+++ b/test/src/models/clients.js
@@ -10,7 +10,7 @@ const { db, random, knex } = require(`${process.cwd()}/test/src/helpers`);
 const _ = require('lodash');
 
 
-describe('Clients Model', () => {
+describe.only('Clients Model', () => {
 	const id = random.guid(),
 		first_name = random.name(),
 		last_name = random.name(),
@@ -33,6 +33,7 @@ describe('Clients Model', () => {
 		await db.resetTable('clients');
 		await db.resetTable('fields');
 		await random.field({ id: field_id, field });
+		await random.clients(20);
 		return random.client(data);
 	});
 


### PR DESCRIPTION
## Overview
Initial purpose was to improve the clients mixin, which was very slow and causing timeout issues. Created specific create methods to not hash password, and changed multi mixins to go through that, so that passwords are only hashed once, and given to very client if we say, create 50 clients, vastly speeding up create performance. Decided to create the freelancer mixins while I was at it. Also, looking at the three user models (Clients, freelancers, and admins), noticed a lot of re-used code, so I decided to abstract the code to the main Model and to create a new 'User' model that the three user models can inherit from, in order to import Dryness. Lastly, updating readme
- [x] change clients mixin
- [x] create freelancers mixin
- [x] test both
- [x] create new model 'Users' so the client, freelancer, and admin models can inherit from it
- [x] pull user-specific code from main model to user model
- [x] abstract relevant data from the 3 user models into UserModel
- [x] update ReadMe (describe project directory and folders)



## Checklist
- Does this PR have unit tests to cover the changes? yes
- Does this PR create migration(s)? no
