### PR TITLE
Add Tests For Flagged Proposals And Invitations

### DIFF
--- a/randoms/index.js
+++ b/randoms/index.js
@@ -211,6 +211,11 @@ random.mixin({
 			opts.field_id = random.guid();
 			await random.field({ id: opts.field_id });
 		}
+		// by creating the client here, we prevent a new client from having to be creted for every job
+		if (!opts.client_id) {
+			opts.client_id = random.guid();
+			await random.client({ id: opts.client_id, field_id: opts.field_id });
+		}
 		// if not given either of these keys, we set the flag to be created by a freelancer by default
 		if (!opts.client_who_flagged && !opts.freelancer_who_flagged) {
 			opts.freelancer_who_flagged = random.guid();

--- a/randoms/index.js
+++ b/randoms/index.js
@@ -175,6 +175,36 @@ random.mixin({
 	},
 
 
+	flagged_invitations: async(count = 10, opts = {}) => {
+		// create a field if not given
+		if (!opts.field_id) {
+			opts.field_id = random.guid();
+			await random.field({ id: opts.field_id });
+		}
+		// we create the client and freelancer here if not given, this saves us the trouble of creating a new client/freelancer for every invitation
+		if (!opts.client_id) {
+			opts.client_id = random.guid();
+			await random.client({ id: opts.client_id, field_id: opts.field_id });
+		}
+		if (!opts.freelancer_id) {
+			opts.freelancer_id = random.guid();
+			await random.freelancer({ id: opts.freelancer_id, field_id: opts.field_id });
+		}
+
+		// if the needed freelancer_who_flagged isn't given, we create it here. This flag can only be created by a freelancer
+		if (!opts.freelancer_who_flagged) {
+			opts.freelancer_who_flagged = random.guid();
+			await random.freelancer({ id: opts.freelancer_who_flagged, field_id: opts.field_id });
+		}
+
+		const flagged_invitations = _.times(count, () => {
+			opts = _.omit(opts, 'invitation_id'); // needs a unique invitation and job for every record
+			return random.flagged_invitation(opts);
+		});
+		return Promise.all(flagged_invitations);
+	},
+
+
 	flagged_jobs: async(count = 10, opts = {}) => {
 		// create a field if not given
 		if (!opts.field_id) {

--- a/randoms/index.js
+++ b/randoms/index.js
@@ -195,6 +195,36 @@ random.mixin({
 	},
 
 
+	flagged_proposals: async(count = 10, opts = {}) => {
+		// create a field if not given
+		if (!opts.field_id) {
+			opts.field_id = random.guid();
+			await random.field({ id: opts.field_id });
+		}
+		// we create the client and freelancer here if not given, this saves us the trouble of creating a new client/freelancer for every proposal
+		if (!opts.client_id) {
+			opts.client_id = random.guid();
+			await random.client({ id: opts.client_id, field_id: opts.field_id });
+		}
+		if (!opts.freelancer_id) {
+			opts.freelancer_id = random.guid();
+			await random.freelancer({ id: opts.freelancer_id, field_id: opts.field_id });
+		}
+
+		// if the needed client_who_flagged isn't given, we create it here. This flag can only be created by a client
+		if (!opts.client_who_flagged) {
+			opts.client_who_flagged = random.guid();
+			await random.client({ id: opts.client_who_flagged, field_id: opts.field_id });
+		}
+
+		const flagged_proposals = _.times(count, () => {
+			opts = _.omit(opts, 'proposal_id'); // needs a unique proposal and job for every record
+			return random.flagged_proposal(opts);
+		});
+		return Promise.all(flagged_proposals);
+	},
+
+
 	freelancer_reviews: async(count = 10, opts = {}) => {
 		// create a field if not given
 		if (!opts.field_id) {

--- a/randoms/mixins/flagged_client.js
+++ b/randoms/mixins/flagged_client.js
@@ -13,7 +13,7 @@ module.exports = async(opts = {}) => {
 	};
 
 
-	// if the needed foreign keys aren't given, we create them here
+	// if the needed client_id isn't given, we create it here
 	if (!opts.client_id) {
 		if (!opts.field_id) await createFieldId();
 		opts.client_id = random.guid();
@@ -30,7 +30,7 @@ module.exports = async(opts = {}) => {
 
 	return FlaggedClients.create({
 		id: opts.id || random.guid(),
-		client_id: opts.client_id || null,
+		client_id: opts.client_id,
 		client_who_flagged: opts.client_who_flagged || null,
 		freelancer_who_flagged: opts.freelancer_who_flagged || null,
 		reason: opts.reason || random.sentence(),

--- a/randoms/mixins/flagged_client_review.js
+++ b/randoms/mixins/flagged_client_review.js
@@ -29,8 +29,12 @@ module.exports = async(opts = {}) => {
 	if (!opts.client_review_id) {
 		if (!opts.client_id) await createClientId();
 		if (!opts.freelancer_id) await createFreelancerId();
+
+		const job_id = random.guid(); // create the job needed for the client_review, creating it here saves us from having to create more fields, clients, and freelancers in the job mixin
+		await random.job({ id: job_id, field_id: opts.field_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, closed: true, available: false });
+
 		opts.client_review_id = random.guid();
-		await random.client_review({ id: opts.client_review_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id });
+		await random.client_review({ id: opts.client_review_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, job_id });
 	}
 
 	// if we aren't given either of these keys, we set the flag to be created by a freelancer by default
@@ -43,7 +47,7 @@ module.exports = async(opts = {}) => {
 
 	return FlaggedClientReviews.create({
 		id: opts.id || random.guid(),
-		client_review_id: opts.client_review_id || null,
+		client_review_id: opts.client_review_id,
 		client_who_flagged: opts.client_who_flagged || null,
 		freelancer_who_flagged: opts.freelancer_who_flagged || null,
 		reason: opts.reason || random.sentence(),

--- a/randoms/mixins/flagged_freelancer.js
+++ b/randoms/mixins/flagged_freelancer.js
@@ -13,7 +13,7 @@ module.exports = async(opts = {}) => {
 	};
 
 
-	// if the needed foreign keys aren't given, we create them here
+	// if the needed freelancer_id isn't given, we create it here
 	if (!opts.freelancer_id) {
 		if (!opts.field_id) await createFieldId();
 		opts.freelancer_id = random.guid();
@@ -30,7 +30,7 @@ module.exports = async(opts = {}) => {
 
 	return FlaggedFreelancers.create({
 		id: opts.id || random.guid(),
-		freelancer_id: opts.freelancer_id || null,
+		freelancer_id: opts.freelancer_id,
 		client_who_flagged: opts.client_who_flagged || null,
 		freelancer_who_flagged: opts.freelancer_who_flagged || null,
 		reason: opts.reason || random.sentence(),

--- a/randoms/mixins/flagged_freelancer_review.js
+++ b/randoms/mixins/flagged_freelancer_review.js
@@ -29,8 +29,12 @@ module.exports = async(opts = {}) => {
 	if (!opts.freelancer_review_id) {
 		if (!opts.client_id) await createClientId();
 		if (!opts.freelancer_id) await createFreelancerId();
+
+		const job_id = random.guid(); // create the job needed for the freelancer_review, creating it here saves us from having to create more fields, clients, and freelancers in the job mixin
+		await random.job({ id: job_id, field_id: opts.field_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, closed: true, available: false });
+
 		opts.freelancer_review_id = random.guid();
-		await random.freelancer_review({ id: opts.freelancer_review_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id });
+		await random.freelancer_review({ id: opts.freelancer_review_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, job_id });
 	}
 
 	// if we aren't given either of these keys, we set the flag to be created by a freelancer by default
@@ -43,7 +47,7 @@ module.exports = async(opts = {}) => {
 
 	return FlaggedFreelancerReviews.create({
 		id: opts.id || random.guid(),
-		freelancer_review_id: opts.freelancer_review_id || null,
+		freelancer_review_id: opts.freelancer_review_id,
 		client_who_flagged: opts.client_who_flagged || null,
 		freelancer_who_flagged: opts.freelancer_who_flagged || null,
 		reason: opts.reason || random.sentence(),

--- a/randoms/mixins/flagged_invitation.js
+++ b/randoms/mixins/flagged_invitation.js
@@ -1,0 +1,54 @@
+'use strict';
+
+
+const random = new (require('chance'));
+const FlaggedInvitations = require(`${process.cwd()}/src/models/flagged_invitations`);
+
+// used to create a random flagged_invitation. If given no parameters, randomizes all fields
+module.exports = async(opts = {}) => {
+	// incase we need a field_id for the below client and freelancers, we only have to create a field once
+	const createFieldId = async() => {
+		opts.field_id = random.guid();
+		await random.field({ id: opts.field_id });
+	};
+
+	// by creating a client and freelancer, we save them and 2 fields from having to be created in the various mixins for the invitation, this is especially helpful in the multi mixin
+	const createClientId = async() => {
+		if (!opts.field_id) await createFieldId();
+		opts.client_id = random.guid();
+		await random.client({ id: opts.client_id, field_id: opts.field_id });
+	};
+	const createFreelancerId = async() => {
+		if (!opts.field_id) await createFieldId();
+		opts.freelancer_id = random.guid();
+		await random.freelancer({ id: opts.freelancer_id, field_id: opts.field_id });
+	};
+
+
+	// if the needed invitation isn't given, we create it here
+	if (!opts.invitation_id) {
+		if (!opts.client_id) await createClientId();
+		if (!opts.freelancer_id) await createFreelancerId();
+
+		const job_id = random.guid(); // create the job needed for the invitation, creating it here saves us from having to create more fields, clients, and freelancers in the job mixin
+		await random.job({ id: job_id, field_id: opts.field_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, closed: false, available: true });
+
+		opts.invitation_id = random.guid();
+		await random.invitation({ id: opts.invitation_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, job_id });
+	}
+
+	// if the needed freelancer_who_flagged isn't given, we create it here. This flag can only be created by a freelancer
+	if (!opts.freelancer_who_flagged) {
+		if (!opts.field_id) await createFieldId();
+		opts.freelancer_who_flagged = random.guid();
+		await random.freelancer({ id: opts.freelancer_who_flagged, field_id: opts.field_id });
+	}
+
+
+	return FlaggedInvitations.create({
+		id: opts.id || random.guid(),
+		invitation_id: opts.invitation_id,
+		freelancer_who_flagged: opts.freelancer_who_flagged,
+		reason: opts.reason || random.sentence(),
+	});
+};

--- a/randoms/mixins/flagged_job.js
+++ b/randoms/mixins/flagged_job.js
@@ -12,12 +12,19 @@ module.exports = async(opts = {}) => {
 		await random.field({ id: opts.field_id });
 	};
 
+	// by creating a client here we save it and a field from having to be created in the job mixins, this is especially helpful in the multi mixin
+	const createClientId = async() => {
+		if (!opts.field_id) await createFieldId();
+		opts.client_id = random.guid();
+		await random.client({ id: opts.client_id, field_id: opts.field_id });
+	};
 
 	// if the needed job isn't given, we create it here
 	if (!opts.job_id) {
 		if (!opts.field_id) await createFieldId();
+		if (!opts.client_id) await createClientId();
 		opts.job_id = random.guid();
-		await random.job({ id: opts.job_id, field_id: opts.field_id });
+		await random.job({ id: opts.job_id, field_id: opts.field_id, client_id: opts.client_id });
 	}
 
 	// if we aren't given either of these keys, we set the flag to be created by a freelancer by default

--- a/randoms/mixins/flagged_proposal.js
+++ b/randoms/mixins/flagged_proposal.js
@@ -1,0 +1,54 @@
+'use strict';
+
+
+const random = new (require('chance'));
+const FlaggedProposals = require(`${process.cwd()}/src/models/flagged_proposals`);
+
+// used to create a random flagged_proposal. If given no parameters, randomizes all fields
+module.exports = async(opts = {}) => {
+	// incase we need a field_id for the below client and freelancers, we only have to create a field once
+	const createFieldId = async() => {
+		opts.field_id = random.guid();
+		await random.field({ id: opts.field_id });
+	};
+
+	// by creating a client and freelancer, we save them and 2 fields from having to be created in the various mixins for the proposal, this is especially helpful in the multi mixin
+	const createClientId = async() => {
+		if (!opts.field_id) await createFieldId();
+		opts.client_id = random.guid();
+		await random.client({ id: opts.client_id, field_id: opts.field_id });
+	};
+	const createFreelancerId = async() => {
+		if (!opts.field_id) await createFieldId();
+		opts.freelancer_id = random.guid();
+		await random.freelancer({ id: opts.freelancer_id, field_id: opts.field_id });
+	};
+
+
+	// if the needed client_review isn't given, we create it here
+	if (!opts.proposal_id) {
+		if (!opts.client_id) await createClientId();
+		if (!opts.freelancer_id) await createFreelancerId();
+
+		const job_id = random.guid(); // create the job needed for the proposal, creating it here saves us from having to create more fields, clients, and freelancers in the job mixin
+		await random.job({ id: job_id, field_id: opts.field_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, closed: false, available: true });
+
+		opts.proposal_id = random.guid();
+		await random.proposal({ id: opts.proposal_id, client_id: opts.client_id, freelancer_id: opts.freelancer_id, job_id });
+	}
+
+	// if the needed client_who_flagged isn't given, we create it here. This flag can only be created by a client
+	if (!opts.client_who_flagged) {
+		if (!opts.field_id) await createFieldId();
+		opts.client_who_flagged = random.guid();
+		await random.client({ id: opts.client_who_flagged, field_id: opts.field_id });
+	}
+
+
+	return FlaggedProposals.create({
+		id: opts.id || random.guid(),
+		proposal_id: opts.proposal_id,
+		client_who_flagged: opts.client_who_flagged,
+		reason: opts.reason || random.sentence(),
+	});
+};

--- a/randoms/mixins/flagged_proposal.js
+++ b/randoms/mixins/flagged_proposal.js
@@ -25,7 +25,7 @@ module.exports = async(opts = {}) => {
 	};
 
 
-	// if the needed client_review isn't given, we create it here
+	// if the needed proposal isn't given, we create it here
 	if (!opts.proposal_id) {
 		if (!opts.client_id) await createClientId();
 		if (!opts.freelancer_id) await createFreelancerId();

--- a/randoms/mixins/index.js
+++ b/randoms/mixins/index.js
@@ -13,6 +13,7 @@ module.exports = {
 	flagged_freelancer_review: require('./flagged_freelancer_review'),
 	flagged_freelancer: require('./flagged_freelancer'),
 	flagged_job: require('./flagged_job'),
+	flagged_proposal: require('./flagged_proposal'),
 	freelancer_review: require('./freelancer_review'),
 	freelancer_skill: require('./freelancer_skill'),
 	freelancer: require('./freelancer'),

--- a/randoms/mixins/index.js
+++ b/randoms/mixins/index.js
@@ -12,6 +12,7 @@ module.exports = {
 	flagged_client: require('./flagged_client'),
 	flagged_freelancer_review: require('./flagged_freelancer_review'),
 	flagged_freelancer: require('./flagged_freelancer'),
+	flagged_invitation: require('./flagged_invitation'),
 	flagged_job: require('./flagged_job'),
 	flagged_proposal: require('./flagged_proposal'),
 	freelancer_review: require('./freelancer_review'),

--- a/src/models/flag_model.js
+++ b/src/models/flag_model.js
@@ -8,6 +8,11 @@ const { toSingular } = require(`${process.cwd()}/src/lib/helper_functions`);
 const _ = require('lodash');
 
 
+// columns used in the knex join statements below, using in multilple methods, so they're declared up here
+const flaggingClientColumns = ['fc.id as client_who_flagged', 'fc.first_name as flagging_client_first_name', 'fc.last_name as flagging_client_last_name'];
+const flaggingFreelancerColumns = ['ff.id as freelancer_who_flagged', 'ff.first_name as flagging_freelancer_first_name', 'ff.last_name as flagging_freelancer_last_name'];
+
+
 // a specific class that extends the MainModel, used only for flag models (flagged_clients, flagged_jobs, etc.), to abstract re-used code and improve DRYness
 class FlagModel extends MainModel {
 	constructor (tableName) {
@@ -68,8 +73,6 @@ class FlagModel extends MainModel {
 	async findOneFlag (id, givenColumn, joinText) {
 		// TODO: put a link in the view leading to the objects (ex: client profile, job page, etc.) for more info, and the to the user who flagged it
 		const flagColumns = [`${this.tableName}.*`];
-		const flaggingClientColumns = ['fc.id as client_who_flagged', 'fc.first_name as flagging_client_first_name', 'fc.last_name as flagging_client_last_name'];
-		const flaggingFreelancerColumns = ['ff.id as freelancer_who_flagged', 'ff.first_name as flagging_freelancer_first_name', 'ff.last_name as flagging_freelancer_last_name'];
 
 		const selectedColumns = flagColumns.concat(flaggingClientColumns, flaggingFreelancerColumns, givenColumn);
 		return knex(this.tableName)
@@ -80,6 +83,47 @@ class FlagModel extends MainModel {
 			.innerJoin(joinText[0], joinText[1], joinText[2])
 			.leftJoin('clients as fc', `${this.tableName}.client_who_flagged`, 'fc.id')
 			.leftJoin('freelancers as ff', `${this.tableName}.freelancer_who_flagged`, 'ff.id')
+			.then((result) => {
+				// throw error if the record with the given id couldn't be found
+				if (!result[0]) throw Errors.notFound(toSingular(this.tableName), 'find');
+
+				return result[0];
+			})
+			.catch((err) => {
+				// throw error if the id wasn't given in proper uuid format
+				if (Errors.violatesIdSyntax(err))
+					throw Errors.badId(toSingular(this.tableName), 'find');
+
+				// if the cause of the error wasn't found above, throw the given error
+				throw err;
+			});
+	}
+
+
+	// this is for the findOne of flagged_proposals and flagged_invitations. They are similar to the above findOne except both models can only be flagged by either a client or a freelancer, this causes errors in the join statements. For example, when you try to join the freelancers table for the freelancer_who_flagged to the flagged_proposal table, it causes an error since it doesn't have a freelancer_who_flagged field
+	findOneInvitation (id, givenColumn, joinText, flaggingUser) {
+		let selectedColumns, userJoinText;
+		// TODO: put a link in the view leading to the objects (ex: client profile, job page, etc.) for more info, and the to the user who flagged it
+		const flagColumns = [`${this.tableName}.*`];
+
+		// based on which user can flag the respective table, we remove the join statement and column related to the other user, and build the appropriate joins statement. Ex: flagged_proposals can only be flagged by clients, so we remove any columns related to freelancers and make the userJoinText join the client and flagged_proposal tables
+		if (flaggingUser === 'client') {
+			selectedColumns = flagColumns.concat(flaggingClientColumns, givenColumn);
+			userJoinText = ['clients as fc', `${this.tableName}.client_who_flagged`, 'fc.id'];
+
+		} else if (flaggingUser === 'freelancer') {
+			selectedColumns = flagColumns.concat(flaggingFreelancerColumns, givenColumn);
+			userJoinText = ['freelancers as ff', `${this.tableName}.freelancer_who_flagged`, 'ff.id'];
+
+		}
+
+		return knex(this.tableName)
+			.select(selectedColumns)
+			.where(knex.raw(`${this.tableName}.id = '${id}'`))
+			// since the join statement for the actual object being flagged (client, job, review, etc.) can be so different, the text is created in the model (flagged_clients, flagged_jobs, etc.) and passed here, to keep it as simple as possible. Example of the joinText below
+			// example of joinText = ['clients as c', 'flagged_clients.client_id', 'c.id']
+			.innerJoin(joinText[0], joinText[1], joinText[2])
+			.innerJoin(userJoinText[0], userJoinText[1], userJoinText[2])
 			.then((result) => {
 				// throw error if the record with the given id couldn't be found
 				if (!result[0]) throw Errors.notFound(toSingular(this.tableName), 'find');

--- a/src/models/flagged_invitations.js
+++ b/src/models/flagged_invitations.js
@@ -1,14 +1,18 @@
 'use strict';
 
 
-const Model = require('./main_model');
+const Model = require('./flag_model');
 const FlaggedInvitations = new Model('flagged_invitations');
+const Errors = require(`${process.cwd()}/src/lib/errors`);
 
 
 module.exports = {
-	// TODO: determine if we need two different methods for the flag being created by the client and by the freelancer. Perhaps it is only one create method, and which parameter (client_who_flagged/freelancer_who_flagged)is sent is determineded in the route
 	create (data) {
-		return FlaggedInvitations.create(data);
+		// a premptive check, saves us trouble in the flag_model create method
+		if (!data.invitation_id)
+			throw Errors.badNull('flagged_invitation', 'create', 'invitation_id');
+
+		return FlaggedInvitations.createFlag(data, 'invitation');
 	},
 
 
@@ -18,7 +22,10 @@ module.exports = {
 
 
 	findOne (id) {
-		return FlaggedInvitations.findOne(id);
+		const invitationColumns = ['i.id as invitation_id', 'i.title as invitation_title', 'i.description as invitation_description'],
+			joinText = ['invitations as p', 'flagged_invitations.invitation_id', 'p.id'];
+
+		return FlaggedInvitations.findOneInvitation(id, invitationColumns, joinText, 'freelancer');
 	},
 
 

--- a/src/models/flagged_invitations.js
+++ b/src/models/flagged_invitations.js
@@ -23,7 +23,7 @@ module.exports = {
 
 	findOne (id) {
 		const invitationColumns = ['i.id as invitation_id', 'i.title as invitation_title', 'i.description as invitation_description'],
-			joinText = ['invitations as p', 'flagged_invitations.invitation_id', 'p.id'];
+			joinText = ['invitations as i', 'flagged_invitations.invitation_id', 'i.id'];
 
 		return FlaggedInvitations.findOneInvitation(id, invitationColumns, joinText, 'freelancer');
 	},

--- a/src/models/flagged_proposals.js
+++ b/src/models/flagged_proposals.js
@@ -21,11 +21,11 @@ module.exports = {
 	},
 
 
-	findOne (id) { // TODO: will this work going through the flag_model? It doesn't have any freelancer_who_flagged fields, but maybe since it's a left join
+	findOne (id) {
 		const proposalColumns = ['p.id as proposal_id', 'p.title as proposal_title', 'p.description as proposal_description'],
 			joinText = ['proposals as p', 'flagged_proposals.proposal_id', 'p.id'];
 
-		return FlaggedProposals.findOneFlag(id, proposalColumns, joinText);
+		return FlaggedProposals.findOneInvitation(id, proposalColumns, joinText, 'client');
 	},
 
 

--- a/test/src/lib/error_methods.js
+++ b/test/src/lib/error_methods.js
@@ -25,7 +25,7 @@ const checkErr = {
 
 			cause: the specific reason that caused the error, ex: not found, violated the not-null constraint
 		*/
-		console.log(err.message);
+		
 		expect(err).to.be.an.object();
 		const { message } = err;
 

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -11,7 +11,7 @@ const Invitations = require(`${process.cwd()}/src/models/invitations`);
 const { db, random, checkErr } = require(`${process.cwd()}/test/src/helpers`);
 
 
-describe.only('Flagged Invitations Model', () => {
+describe('Flagged Invitations Model', () => {
 	// only freelancers can create a flagged_invitation
 	const id = random.guid(),
 		invitation_id = random.guid(),

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -136,7 +136,29 @@ describe.only('Flagged Invitations Model', () => {
 
 
 	describe('has a findOne method', () => {
+		it('should retrieve a specific flagged_invitation record with a given id, and return the object with relevant information about the invitation that was flagged, the freelancer who flagged it', async() => {
+			const flagged_invitation = await FlaggedInvitations.findOne(id);
 
+			expect(flagged_invitation).to.be.an.object();
+			expect(flagged_invitation.id).to.equal(id);
+			expect(flagged_invitation.invitation_id).to.equal(invitation_id);
+			expect(flagged_invitation.invitation_title).to.equal(title);
+			expect(flagged_invitation.invitation_description).to.equal(description);
+			expect(flagged_invitation.freelancer_who_flagged).to.equal(freelancer_who_flagged);
+			expect(flagged_invitation.flagging_freelancer_first_name).to.equal(first_name);
+			expect(flagged_invitation.flagging_freelancer_last_name).to.equal(last_name);
+			expect(flagged_invitation.reason).to.equal(reason);
+			expect(flagged_invitation.created_at).to.be.a.date();
+			expect(flagged_invitation.updated_at).to.equal(null);
+		});
+
+		it('should raise an exception if given an incorrect id (not found)', async() => {
+			return checkErr.checkNotFound(FlaggedInvitations, 'flagged_invitation', 'find', random.guid());
+		});
+
+		it('should raise an exception when given an invalid id (not in uuid format)', async() => {
+			return checkErr.checkIdFormat(FlaggedInvitations, 'flagged_invitation', 'find', {});
+		});
 	});
 
 

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -1,0 +1,34 @@
+'use strict';
+
+
+const { expect } = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const { describe, it, before } = lab;
+const FlaggedInvitations = require(`${process.cwd()}/src/models/flagged_invitations`);
+const Freelancers = require(`${process.cwd()}/src/models/freelancers`);
+const Invitations = require(`${process.cwd()}/src/models/invitations`);
+const { db, random, checkErr } = require(`${process.cwd()}/test/src/helpers`);
+
+
+describe('Flagged Invitations Model', () => {
+
+	describe('has a create method', () => {
+
+	});
+
+
+	describe('has a findOne method', () => {
+
+	});
+
+
+	describe('has a delete method', () => {
+
+	});
+
+
+	describe('has cascading delete on invitation_id and freelancer_who_flagged', () => {
+
+	});
+});

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -163,7 +163,28 @@ describe.only('Flagged Invitations Model', () => {
 
 
 	describe('has a delete method', () => {
+		it('should delete the record if given a correct id and return true if successful', async() => {
+			const createData = await createNewData(),
+				specificId = createData.id,
+				flagged_invitation = await random.flagged_invitation(createData);
 
+			expect(flagged_invitation).to.be.an.object();
+			expect(flagged_invitation.id).to.equal(specificId);
+
+			const result = await FlaggedInvitations.delete(specificId);
+			expect(result).to.equal(true);
+
+			// check that trying to find the record now returns a not found error
+			return checkErr.checkNotFound(FlaggedInvitations, 'flagged_invitation', 'find', specificId);
+		});
+
+		it('should raise an exception if given an incorrect id (not found)', async() => {
+			return checkErr.checkNotFound(FlaggedInvitations, 'flagged_invitation', 'delete', random.guid());
+		});
+
+		it('should raise an exception when given an invalid id (not in uuid format)', async() => {
+			return checkErr.checkIdFormat(FlaggedInvitations, 'flagged_invitation', 'delete', {});
+		});
 	});
 
 

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -189,6 +189,37 @@ describe.only('Flagged Invitations Model', () => {
 
 
 	describe('has cascading delete on invitation_id and freelancer_who_flagged', () => {
+		it('should be deleted in the event of the invitation that was flagged is deleted.', async() => {
+			const createData = await createNewData(),
+				specificId = createData.id,
+				specificInvitationId = createData.invitation_id,
+				flagged_invitation = await random.flagged_invitation(createData);
 
+			expect(flagged_invitation).to.be.an.object();
+			expect(flagged_invitation.id).to.equal(specificId);
+			expect(flagged_invitation.invitation_id).to.equal(specificInvitationId);
+
+			const result = await Invitations.delete(specificInvitationId);
+			expect(result).to.equal(true);
+
+			// check that trying to find the record now returns a not found error
+			return checkErr.checkNotFound(FlaggedInvitations, 'flagged_invitation', 'find', specificId);
+		});
+
+		it('should be deleted in the event of the freelancer who created the flag is deleted.', async() => {
+			const createData = await createNewData(),
+				specificId = createData.id,
+				flagged_invitation = await random.flagged_invitation(createData);
+
+			expect(flagged_invitation).to.be.an.object();
+			expect(flagged_invitation.id).to.equal(specificId);
+			expect(flagged_invitation.freelancer_who_flagged).to.equal(freelancer_who_flagged);
+
+			const result = await Freelancers.delete(freelancer_who_flagged);
+			expect(result).to.equal(true);
+
+			// check that trying to find the record now returns a not found error
+			return checkErr.checkNotFound(FlaggedInvitations, 'flagged_invitation', 'find', specificId);
+		});
 	});
 });

--- a/test/src/models/flagged_invitations.js
+++ b/test/src/models/flagged_invitations.js
@@ -11,10 +11,43 @@ const Invitations = require(`${process.cwd()}/src/models/invitations`);
 const { db, random, checkErr } = require(`${process.cwd()}/test/src/helpers`);
 
 
-describe('Flagged Invitations Model', () => {
+describe.only('Flagged Invitations Model', () => {
+	// only freelancers can create a flagged_invitation
+	const id = random.guid(),
+		invitation_id = random.guid(),
+		client_id = random.guid(), // the client that writes the invitation, saves us having to create a client for each one
+		freelancer_id = random.guid(), // the freelancer that each invitation will be for, saves us having to create a freelancer for each one
+		freelancer_who_flagged = random.guid(),
+		reason = random.sentence(),
+		field_id = random.guid(),
+		data = { id, invitation_id, freelancer_who_flagged, reason };
+
+	// variables used to specify fields of the clients and freelancers, used in the tests below
+	const title = random.word(),
+		description = random.paragraph(),
+		first_name = random.name(),
+		last_name = random.name(),
+
+		invitationData = { id: invitation_id, client_id, freelancer_id, title, description },
+
+		freelancerData = { id: freelancer_who_flagged, field_id, first_name, last_name };
+
+
+	before(async() => {
+		await db.resetAll();
+		// await random.field({ id: field_id });
+		// await random.client({ id: client_id, field_id });
+		// await random.freelancer({ id: freelancer_id, field_id });
+		// await random.invitation(invitationData);
+		// await random.freelancer(freelancerData);
+		// await random.flagged_invitation(data);
+		await random.flagged_invitations();
+	});
 
 	describe('has a create method', () => {
+		it('text', async() => {
 
+		});
 	});
 
 

--- a/test/src/models/flagged_proposals.js
+++ b/test/src/models/flagged_proposals.js
@@ -12,10 +12,42 @@ const Proposals = require(`${process.cwd()}/src/models/proposals`);
 const { db, random, checkErr } = require(`${process.cwd()}/test/src/helpers`);
 
 
-describe('Flagged Proposals Model', () => {
+describe.only('Flagged Proposals Model', () => {
+	// only clients can create a flagged_proposal
+	const id = random.guid(),
+		proposal_id = random.guid(),
+		client_id = random.guid(), // the client that each proposal will be for, saves us having to create a client for each one
+		freelancer_id = random.guid(), // the freelancer that writes the proposal, saves us having to create a freelancer for each one
+		client_who_flagged = random.guid(),
+		reason = random.sentence(),
+		field_id = random.guid(),
+		data = { id, proposal_id, client_who_flagged, reason };
+
+	// variables used to specify fields of the clients and freelancers, used in the tests below
+	const title = random.word(),
+		description = random.paragraph(),
+		first_name = random.name(),
+		last_name = random.name(),
+
+		proposalData = { id: proposal_id, client_id, freelancer_id, title, description },
+
+		clientData = { id: client_who_flagged, field_id, first_name, last_name };
+
+
+	before(async() => {
+		await db.resetAll();
+		await random.field({ id: field_id });
+		await random.client({ id: client_id, field_id });
+		await random.freelancer({ id: freelancer_id, field_id });
+		await random.proposal(proposalData);
+		await random.client(clientData);
+		await random.flagged_proposal(data);
+	});
 
 	describe('has a create method', () => {
+		it('text', async() => {
 
+		});
 	});
 
 

--- a/test/src/models/flagged_proposals.js
+++ b/test/src/models/flagged_proposals.js
@@ -187,7 +187,7 @@ describe('Flagged Proposals Model', () => {
 	});
 
 
-	describe('has cascading delete on proposal_id, client_who_flagged, and freelancer_who_flagged', () => {
+	describe('has cascading delete on proposal_id and client_who_flagged', () => {
 		it('should be deleted in the event of the proposal that was flagged is deleted.', async() => {
 			const createData = await createNewData(),
 				specificId = createData.id,

--- a/test/src/models/flagged_proposals.js
+++ b/test/src/models/flagged_proposals.js
@@ -136,7 +136,29 @@ describe.only('Flagged Proposals Model', () => {
 
 
 	describe('has a findOne method', () => {
+		it('should retrieve a specific flagged_proposal record with a given id, and return the object with relevant information about the proposal that was flagged, the client who flagged it', async() => {
+			const flagged_proposal = await FlaggedProposals.findOne(id);
 
+			expect(flagged_proposal).to.be.an.object();
+			expect(flagged_proposal.id).to.equal(id);
+			expect(flagged_proposal.proposal_id).to.equal(proposal_id);
+			expect(flagged_proposal.proposal_title).to.equal(title);
+			expect(flagged_proposal.proposal_description).to.equal(description);
+			expect(flagged_proposal.client_who_flagged).to.equal(client_who_flagged);
+			expect(flagged_proposal.flagging_client_first_name).to.equal(first_name);
+			expect(flagged_proposal.flagging_client_last_name).to.equal(last_name);
+			expect(flagged_proposal.reason).to.equal(reason);
+			expect(flagged_proposal.created_at).to.be.a.date();
+			expect(flagged_proposal.updated_at).to.equal(null);
+		});
+
+		it('should raise an exception if given an incorrect id (not found)', async() => {
+			return checkErr.checkNotFound(FlaggedProposals, 'flagged_proposal', 'find', random.guid());
+		});
+
+		it('should raise an exception when given an invalid id (not in uuid format)', async() => {
+			return checkErr.checkIdFormat(FlaggedProposals, 'flagged_proposal', 'find', {});
+		});
 	});
 
 

--- a/test/src/models/flagged_proposals.js
+++ b/test/src/models/flagged_proposals.js
@@ -66,6 +66,7 @@ describe('Flagged Proposals Model', () => {
 		expect(obj.updated_at).to.equal(null);
 	};
 
+
 	describe('has a create method', () => {
 		it('should allow you to create a new flagged_proposal if given valid data with the flag being created by a client (client_who_flagged), create new created_at and updated_at fields, and return the new flagged_proposal object', async() => {
 			const createData = await createNewData(),

--- a/test/src/models/flagged_proposals.js
+++ b/test/src/models/flagged_proposals.js
@@ -1,0 +1,35 @@
+'use strict';
+
+
+const { expect } = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const { describe, it, before } = lab;
+const FlaggedProposals = require(`${process.cwd()}/src/models/flagged_proposals`);
+const Clients = require(`${process.cwd()}/src/models/clients`);
+const Freelancers = require(`${process.cwd()}/src/models/freelancers`);
+const Proposals = require(`${process.cwd()}/src/models/proposals`);
+const { db, random, checkErr } = require(`${process.cwd()}/test/src/helpers`);
+
+
+describe('Flagged Proposals Model', () => {
+
+	describe('has a create method', () => {
+
+	});
+
+
+	describe('has a findOne method', () => {
+
+	});
+
+
+	describe('has a delete method', () => {
+
+	});
+
+
+	describe('has cascading delete on proposal_id, client_who_flagged, and freelancer_who_flagged', () => {
+
+	});
+});


### PR DESCRIPTION
## Overview
Purpose is to add tests for the flagged_proposals and flagged_invitations models and make any necessary changes to the model

- [x] create test file proposals
- [x] change model as necessary
- [x] create mixin for proposals
- [x] test create method proposals
- [x] test getAll method proposals
- [x] test findOne method proposals
- [x] test delete method proposals
- [x] test cascading delete proposals
- [x] create test file Invitations
- [x] change model as necessary
- [x] create mixin for Invitations
- [x] test create method Invitations
- [x] test getAll method Invitations
- [x] test findOne method Invitations
- [x] test delete method Invitations
- [x] test cascading delete Invitations
- [ ] make any other necessary changes
- [x] clean up all flagged mixins (remove possible null values where applicable. For flagged clients/freelancer reviews, create the needed unique job in that mixin so you can give it the same client/freelancer, etc.)


## Checklist
- Does this PR have unit tests to cover the changes? yes
- Does this PR create migration(s)? no